### PR TITLE
Attempt to nix stalled spider processes

### DIFF
--- a/htcondor_es/spider.py
+++ b/htcondor_es/spider.py
@@ -32,7 +32,7 @@ def main_driver(args):
         startd_ads = utils.get_startds(args)
         logging.warning("&&& There are %d startds to query.", len(startd_ads))
 
-    with multiprocessing.Pool(processes=args.process_parallel_queries) as pool:
+    with multiprocessing.Pool(processes=args.process_parallel_queries, maxtasksperchild=1) as pool:
         metadata = utils.collect_metadata()
 
         if args.process_schedd_history:


### PR DESCRIPTION
Two changes to try to resolve #20 :
1. Forbid multiprocessing from re-using forked processes (`maxtasksperchild=1`)
2. Fixed a bug where a call to `utils.time_remaining()` wasn't passing back negative values (useful for allowing a small time buffer before calling `pool.terminate()` if the entire processing queue times out)

I'm not 100% certain that these changes have solved the problem, however I was able to reproduce having a bunch of stalled `spider` processes by changing the (hardcoded) `utils.TIMEOUT_MINS` from 11 minutes to 1 minute. It seems like doing this with the current master code causes https://github.com/CHTC/chtc-htcondor-es/blob/76366036f755972626d2654fea0a2c7f1f776d29/htcondor_es/spider.py#L21 to trigger, which leads to the current problem. Making the changes in this PR prevented the alarm from triggering and kept the zombie processes from showing up again.

There is going to be a performance hit from not allowing re-use of forked procs, but for something like this that is meant to run unmonitored in a cron job, it seems like trading some safety for performance is worth it.